### PR TITLE
Make postgres dependency conditional.

### DIFF
--- a/Formula/pgcli.rb
+++ b/Formula/pgcli.rb
@@ -1,3 +1,19 @@
+class PostgresRequirement < Requirement
+  fatal true
+
+  default_formula "postgresql"
+
+  satisfy { which "pg_config" }
+
+  def satisfied?
+    return_value = super
+    # Do not let Homebrew realize this requirement is satisfied by a formula.
+    # That way it won't try to update the formula.
+    @formula = nil
+    return_value
+  end
+end
+
 class Pgcli < Formula
   include Language::Python::Virtualenv
 
@@ -9,9 +25,7 @@ class Pgcli < Formula
 
   depends_on :python
   depends_on "openssl"
-
-  # Do not upgrade the postgresql Formula if it's installed.
-  depends_on :postgresql unless Formula["postgresql"].installed?
+  depends_on PostgresRequirement
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz"
@@ -69,9 +83,6 @@ class Pgcli < Formula
   end
 
   def install
-    # Append Homebrew's bin directory to the PATH so Psycopg can find the pg_config binary.
-    ENV.append_path "PATH", "#{HOMEBREW_PREFIX}/bin"
-
     virtualenv_install_with_resources
   end
 

--- a/Formula/pgcli.rb
+++ b/Formula/pgcli.rb
@@ -8,7 +8,9 @@ class Pgcli < Formula
 
   depends_on :python
   depends_on "openssl"
-  depends_on :postgresql
+
+  # Do not upgrade the postgresql Formula if it's installed.
+  depends_on :postgresql unless Formula["postgresql"].installed?
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/95/d9/c3336b6b5711c3ab9d1d3a80f1a3e2afeb9d8c02a7166462f6cc96570897/click-6.7.tar.gz"
@@ -66,6 +68,9 @@ class Pgcli < Formula
   end
 
   def install
+    # Append Homebrew's bin directory to the PATH so Psycopg can find the pg_config binary.
+    ENV.append_path "PATH", "#{HOMEBREW_PREFIX}/bin"
+
     virtualenv_install_with_resources
   end
 


### PR DESCRIPTION
This makes the PostgreSQL dependency conditional when installing pgcli.

Caveats:
- Users can `brew uninstall postgres` without being warned that `pgcli` depends on it.

If possible please test install this formula with and without Postgres installed. Here's how you can test it:
```bash
$ brew update
$ brew tap-pin dbcli/tap
$ cd $(brew --repository dbcli/tap)
$ git fetch origin
$ git checkout conditional_postgres_dependency
$ brew install pgcli
$ pgcli --help
```